### PR TITLE
[Bug Fix] Show postings that are closed today in the search results

### DIFF
--- a/app/models/position_opening.rb
+++ b/app/models/position_opening.rb
@@ -119,6 +119,12 @@ class PositionOpening
               end
             end
 
+            filter do
+              range :end_date do
+                gte Date.current
+              end
+            end
+
             must { term source: source } if source.present?
             must { terms tags: tags } if tags
             if query.position_offering_type_code.present?
@@ -229,7 +235,6 @@ class PositionOpening
       end.to_hash
 
       search_results = __elasticsearch__.search(definition, index: INDEX_NAME)
-
       Rails.logger.info("[Query] #{options.merge(result_count: search_results.results.total).to_json}")
 
       search_results.results.collect do |item|
@@ -324,7 +329,7 @@ class PositionOpening
               bool do
                 should do
                   range :end_date do
-                    lte Date.current
+                    lt Date.current
                   end
                 end
 
@@ -341,6 +346,10 @@ class PositionOpening
                       end
                     end
                   end
+                end
+
+                should do
+                  script script: "doc['start_date'].value > doc['end_date'].value"
                 end
               end
             end

--- a/lib/importers/usajobs_data.rb
+++ b/lib/importers/usajobs_data.rb
@@ -40,7 +40,7 @@ class UsajobsData
     entry[:external_id] = job_xml.xpath(XPATHS[:id]).inner_text.to_i
     entry[:locations] = process_locations(job_xml)
     entry[:locations] = [] if entry[:locations].size >= CATCHALL_THRESHOLD
-    # entry[:_ttl] = (days_remaining.zero? || entry[:locations].empty?) ? '1s' : "#{days_remaining}d"
+
     unless entry[:locations].empty? || days_remaining.zero?
       entry[:position_title] = job_xml.xpath(XPATHS[:position_title]).inner_text.strip
       entry[:organization_id] = job_xml.xpath(XPATHS[:organization_id]).inner_text.strip.upcase

--- a/spec/lib/importers/neogov_data_spec.rb
+++ b/spec/lib/importers/neogov_data_spec.rb
@@ -111,27 +111,27 @@ describe NeogovData do
       end
     end
 
-    # context 'when invalid/expired position openings are in the feed' do
-    #   let(:expired_importer) { NeogovData.new('michigan', 'state', 'USMI') }
-    #
-    #   before do
-    #     allow(expired_importer).to receive(:fetch_jobs_rss).and_return File.open('spec/resources/neogov/expired.rss')
-    #   end
-    #
-    #   it 'should set their ttl to 1s' do
-    #     expect(PositionOpening).to receive(:get_external_ids_by_source).with('ng:michigan').and_return([])
-    #     expect(PositionOpening).to receive(:import) do |position_openings|
-    #       expect(position_openings.length).to eq(1)
-    #
-    #       expect(position_openings[0]).to eq(
-    #         {type: 'position_opening', source: 'ng:michigan',
-    #          organization_id: 'USMI', organization_name: 'State of Michigan, MI', tags: %w(state),
-    #          external_id: 282662, locations: [{city: 'Freeland', state: 'MI'}], ttl: '1s'}
-    #       )
-    #     end
-    #     expired_importer.import
-    #   end
-    # end
+    context 'when invalid/expired position openings are in the feed' do
+      let(:expired_importer) { NeogovData.new('michigan', 'state', 'USMI') }
+
+      before do
+        allow(expired_importer).to receive(:fetch_jobs_rss).and_return File.open('spec/resources/neogov/expired.rss')
+      end
+
+      it 'should still load the data' do
+        expect(PositionOpening).to receive(:get_external_ids_by_source).with('ng:michigan').and_return([])
+        expect(PositionOpening).to receive(:import) do |position_openings|
+          expect(position_openings.length).to eq(1)
+
+          expect(position_openings[0]).to eq(
+            {type: 'position_opening', source: 'ng:michigan',
+             organization_id: 'USMI', organization_name: 'State of Michigan, MI', tags: %w(state),
+             external_id: 282662, locations: [{city: 'Freeland', state: 'MI'}]}
+          )
+        end
+        expired_importer.import
+      end
+    end
 
     context 'when the city or state is invalid' do
       let(:bad_location_importer) { NeogovData.new('michigan', 'state', 'USMI') }

--- a/spec/lib/importers/usajobs_data_spec.rb
+++ b/spec/lib/importers/usajobs_data_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 describe UsajobsData do
   let(:importer) { UsajobsData.new('doc/sample.xml') }
   let(:far_away) { Date.parse('2022-01-31') }
-  let(:ttl) { "#{(far_away - Date.current).to_i}d" }
 
   describe '#import' do
     it 'should load the PositionOpenings from filename' do
@@ -45,7 +44,7 @@ describe UsajobsData do
     context 'when records have been somehow marked as inactive/closed/expired' do
       let(:anti_importer) { UsajobsData.new('spec/resources/usajobs/anti_sample.xml') }
 
-      it 'should load the records with a ttl of 1s' do
+      it 'should load the records' do
         expect(PositionOpening).to receive(:import) do |position_openings|
           expect(position_openings.length).to eq(3)
           expect(position_openings[0]).to eq(


### PR DESCRIPTION
Refer to: [Issue](https://github.com/GSA/jobs_api/issues/7)
### Problem
Postings that are closed today are previously deleted using ES feature that deletes
docs that are marked as expired (```_ttl```). As we did not specify that the docs should expire
end of the day, the postings that are ended today are deleted automatically. Hence, these
postings do not show up in the search results.

### Fix
Only delete docs with end_date that are less than ```Date.current``` in the cron job. Show all docs that have end_date greater or equal to today.