### PR TITLE
Revert "SRCH-66 - Update security vulnerability for gem ffi"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.25)
+    ffi (1.9.18)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
@@ -256,4 +256,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.2
+   1.16.1


### PR DESCRIPTION
Reverts GSA/jobs_api#26
Reverting so that I can tag the branch with a version first.