### PR TITLE
update USAJOBS README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jobs API Server
 [![Code Climate](https://codeclimate.com/github/GSA/jobs_api/badges/gpa.svg)](https://codeclimate.com/github/GSA/jobs_api)
 [![Test Coverage](https://codeclimate.com/github/GSA/jobs_api/badges/coverage.svg)](https://codeclimate.com/github/GSA/jobs_api)
 
-**NOTE:** Important Note: The Jobs API will be deprecated early 2019. Please use the [USAJOBS API](https://developer.usajobs.gov/) instead.
+**IMPORTANT NOTE:** The Jobs API will be deprecated early 2019. Please use the [USAJOBS API](https://developer.usajobs.gov/) instead.
 
 USAJOBS now provides a direct API for retrieving job postings with the U.S. federal government. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jobs API Server
 
 **NOTE:** Important Note: The Jobs API will be deprecated early 2019. Please use the [USAJOBS API](https://developer.usajobs.gov/) instead.
 
-USAJobs now provides a direct API for retrieving job postings with the U.S. federal government. 
+USAJOBS now provides a direct API for retrieving job postings with the U.S. federal government. 
 
 The API in this repo is primarily for use by Search.gov.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Jobs API Server
 [![Code Climate](https://codeclimate.com/github/GSA/jobs_api/badges/gpa.svg)](https://codeclimate.com/github/GSA/jobs_api)
 [![Test Coverage](https://codeclimate.com/github/GSA/jobs_api/badges/coverage.svg)](https://codeclimate.com/github/GSA/jobs_api)
 
-**NOTE:** USAJobs now provides a direct API for retrieving job postings with the U.S. federal government. Please leverage that API for any new projects: https://developer.usajobs.gov/
+**NOTE:** Important Note: The Jobs API will be deprecated early 2019. Please use the [USAJOBS API](https://developer.usajobs.gov/) instead.
+
+USAJobs now provides a direct API for retrieving job postings with the U.S. federal government. 
 
 The API in this repo is primarily for use by Search.gov.
 


### PR DESCRIPTION
By Dawns request before shutdown to place the deprecation notice for jobs api repo. We will copy the same message that is in place for  https://search.gov/developer/jobs.html. 
